### PR TITLE
create issues script

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -2,3 +2,21 @@
 
 This Jakarta EE Release repository will be used to help manage the various Jakarta EE releases.
 No deliverable code will be housed in this repository -- only Issues, PRs, Tools, etc in support of delivering a Jakarta EE release.
+
+== EE4J Tools
+
+A set of scripts simplifying work with EE4J project.
+
+=== batch-create-issues
+
+Creates issues in multiple EE4J repositories based on provided template.
+Anybody can create issues, but you will need to be a committer to modify the issue after it's been created (ie. labels, milestones, etc).
+
+Usage:
+
+- Modify `repos` list in `create_issues.sh` with names of repositories you want to create an issue in
+- Put your issue text in `issue.md` file.
+- The Title of the issue is generated via the `create_issues.sh` script.
+An alternative is to include the Title as the first line in the `issue.md` file.
+An empty line after that first Title line is required.
+- Run `create_issues.sh`

--- a/ee4j-tools/batch-create-issues/create_issues.sh
+++ b/ee4j-tools/batch-create-issues/create_issues.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+# All Jakarta EE Specification repos
+repos=(jakartaee-platform faces-api jta-api jsonb-api jsonp jms-api jpa-api websocket-api concurrency-api servlet-api jsp-api common-annotations-api jaxrs-api injection-spec jstl-api cdi jax-ws-api jaspic jaxb-api batch-api el-ri jws-api saaj-api interceptor-api ejb-api security-api jacc beanvalidation-spec jca-api javamail jaf)
+# used for testing...
+# repos=(jakartaee-platform)
+issue_file="issue.md"
+
+for r in "${repos[@]}"
+do
+    if [ ! -d "$r" ]; then
+        hub clone "https://github.com/eclipse-ee4j/$r"
+    fi
+
+    cd "$r"
+    echo "[$r] creating issue"
+    # Generate first line as Title of Issue
+    echo -e "Deliver $r Specification Version update for Jakarta EE 9\n$(cat ../$issue_file)" > issue.txt
+    # Attempt to assign the label "Epic" -- the issue creation will not fail if the "Epic" label does not exist
+    hub issue create -F issue.txt -l Epic
+    cd ..
+done

--- a/ee4j-tools/batch-create-issues/issue.md
+++ b/ee4j-tools/batch-create-issues/issue.md
@@ -1,0 +1,35 @@
+
+**Is your feature request related to a problem? Please describe.**
+Jakarta EE 9 is the next major release, with the main focus of moving from the ```javax``` namespace to the ```jakarta``` namespace.
+
+**Describe the solution you'd like**
+This issue will be used to track the progress of this work effort via the [Jakarta EE 9 Project board](https://github.com/orgs/eclipse-ee4j/projects/17).
+
+**Additional context**
+[Jakarta EE Specification Process](https://jakarta.ee/about/jesp/)
+[Eclipse Project Handbook](https://www.eclipse.org/projects/handbook/#release)
+[Eclipse Release Record for Jakarta EE 9](https://projects.eclipse.org/projects/ee4j.jakartaee-platform/releases/9)
+
+**ToDo**
+- [ ] **[Create Eclipse Release Record](https://www.eclipse.org/projects/handbook/#pmi-commands-release) in your respective Jakarta Specification Project.**
+ Most Component Release Records will just reference the [Jakarta EE 9 Platform Release Plan](https://eclipse-ee4j.github.io/jakartaee-platform/jakartaee9/JakartaEE9ReleasePlan).  But, if your Component deviates at all from the Platform Release Plan, then a description of the changes will be required in the Release Record.
+- [ ] **Initiate a ballot for your Jakarta Release Record/Plan.**
+ Again, if your component is only doing the required minimum as defined by the [Jakarta EE 9 Platform Release Plan](https://eclipse-ee4j.github.io/jakartaee-platform/jakartaee9/JakartaEE9ReleasePlan), then no separate ballot is required.  You are already approved.  But, if your component deviates from the Platform Release Plan, then you will need to initiate your own ballot as defined by the [Jakarta EE Specification Process](https://jakarta.ee/about/jesp/).
+- [ ] **Jakarta-ize your Specification document (if applicable)**
+ Many of the Jakarta EE components now have the source for their Specification documents.  It is strongly recommended that these Specification documents are properly updated to represent Jakarta EE instead of Java EE.  Some [helpful instructions are documented](https://github.com/jakartaee/specification-committee/blob/master/steps_javaee_to_jakartaee.adoc) here.
+- [ ] **javax -> jakarta Spec updates**
+ If your component has Specification source, then all javax package references need to be updated to use jakarta package references.
+- [ ] **javax -> jakarta API updates**
+ Your component APIs need to move from using the javax namespace to using the jakarta namespace.
+- [ ] **Release Candidate (RC) of Jakarta API in Maven Central**
+ A Release Candidate of your component API should be pushed to Maven Central as soon as humanly possible.  This will allow other dependent components to utilize your APIs as they are updating their APIs.  Multiple revisions of these Release Candidate APIs are allowed (and probably expected) during the development cycle.
+- [ ] **javax -> jakarta TCK updates**
+ Your component TCK needs to be updated to use the jakarta namespace.
+- [ ] **javax -> jakarta Compatible Implementation updates**
+ Your compatible implementation that will be used to demonstrate completeness of the Specification needs to be updated to use the jakarta namespace.
+- [ ] **Final Jakarta API available in Staging Repo**
+ When ready, your final version of the API needs to be staged to get ready for the PR review and approvals.
+- [ ] **Draft Specification and Apidoc PRs ready for review**
+ Like we did for Jakarta EE 8, draft PRs need to be created and reviewed in preparation for the final ballots.
+- [ ] **Release Review Ballot started**
+ Each Jakarta EE component will need to initiate a separate Release Review ballot after proper reviewing has completed.  To be clear, there will not be a blanket Release Review for all of Jakarta EE 9 like we did for the Plan Review.  Each component needs a separate Release Review.


### PR DESCRIPTION
Signed-off-by: Kevin Sutter <kwsutter@gmail.com>

This script was used to easily create all of the "Deliver xyz Specification Version" Issues for the Jakarta EE 9 release.  The original version was obtained from @m0mus and I think he got the idea from @dblevins.  So, thanks to both of them for the idea.

I modified the script slightly to make it more flexible and more "personal" for each repository.  I thought by putting the scripts here in this jakartaee-release repo then they could more easily be shared for future Jakarta EE releases.